### PR TITLE
fix: case-sensitive header lookup in HttpResponse getValue method

### DIFF
--- a/flex-api-ios-sdk/FlexTokens Feature/HttpResponse.swift
+++ b/flex-api-ios-sdk/FlexTokens Feature/HttpResponse.swift
@@ -11,7 +11,6 @@ struct HttpResponse: Equatable {
     static func == (lhs: HttpResponse, rhs: HttpResponse) -> Bool {
         return lhs.status == rhs.status && lhs.body == rhs.body
     }
-    
     let status: Int
     let body: String?
     let headers: [AnyHashable: Any]?
@@ -21,16 +20,18 @@ struct HttpResponse: Equatable {
         self.body = body
         self.headers = headers
     }
-    
     func isValidResponse() -> Bool {
         (200...299).contains(self.status)
     }
-    
     func getValue(for key: String) -> String? {
-        if let field = self.headers?[key.lowercased()] as? String {
-             return field
-         }
-        
-        return nil
+        // attempt to get header value using exact key
+        if let field = self.headers?[key] as? String {
+            return field
+        }
+
+        // Then try case-insensitive match if needed
+        return self.headers?.first(where: {
+            ($0.key as? String)?.lowercased() == key.lowercased()
+        })?.value as? String
     }
 }


### PR DESCRIPTION
### Description
Currently, the `getValue` method in HttpResponse performs a case-sensitive lookup of header keys after lowercasing the input key. This causes issues when response headers like "Digest" need to be retrieved as part of verification.

While creating the transient token, response from  `/flex/v2/tokens` request contains a response header of `Digest`. Calling `DigestHelper.verifyResponseDigest()` will always throw a `missingDigestHeader` error when attempting to assign `digestHeader` value:
```swift
guard let digestHeader = response.getValue(for: "Digest") else {
    throw FlexInternalErrors.missingDigestHeader.errorResponse
}
```

This change modifies the `HttpResponse.getValue()` function to:
1. First attempt an exact key match
2. Only apply case-insensitive comparison if exact match fails
